### PR TITLE
Refactor controllers

### DIFF
--- a/__tests__/institution.spec.ts
+++ b/__tests__/institution.spec.ts
@@ -1,7 +1,7 @@
 import request from 'supertest';
 import { app } from '../src/main';
 
-describe('GET /instituition', () => {});
+describe('GET /instituition', () => { });
 
 describe('CRUD instituition', () => {
   const instituition = {
@@ -22,7 +22,7 @@ describe('CRUD instituition', () => {
       .set('Accept', 'application/json')
       .send(instituition);
     expect(res.status).toBe(201);
-    expect(res.body.name).toBe(instituition.name);
+    expect(res.body).toMatchObject(instituition);
 
     instituition_id = res.body._id;
   });
@@ -44,7 +44,7 @@ describe('CRUD instituition', () => {
   });
   it('delete instituition', async () => {
     const res = await request(app)
-      .put(`/instituition/${instituition_id}`)
+      .delete(`/instituition/${instituition_id}`)
       .set('Accept', 'application/json');
     expect(res.status).toBe(200);
   });

--- a/__tests__/pet.spec.ts
+++ b/__tests__/pet.spec.ts
@@ -1,7 +1,7 @@
 import request from 'supertest';
 import { app } from '../src/main';
 
-describe('GET /pet', () => {});
+describe('GET /pet', () => { });
 
 describe('CRUD pet', () => {
   const pet = {
@@ -20,7 +20,7 @@ describe('CRUD pet', () => {
       .set('Accept', 'application/json')
       .send(pet);
     expect(res.status).toBe(201);
-    expect(res.body.name).toBe(pet.name);
+    expect(res.body).toMatchObject(pet);
 
     pet_id = res.body._id;
   });
@@ -40,7 +40,7 @@ describe('CRUD pet', () => {
   });
   it('delete pet', async () => {
     const res = await request(app)
-      .put(`/pet/${pet_id}`)
+      .delete(`/pet/${pet_id}`)
       .set('Accept', 'application/json');
     expect(res.status).toBe(200);
   });

--- a/__tests__/transaction.spec.ts
+++ b/__tests__/transaction.spec.ts
@@ -1,13 +1,13 @@
 import request from 'supertest';
 import { app } from '../src/main';
 
-describe('GET /transaction', () => {});
+describe('GET /transaction', () => { });
 
 describe('CRUD transaction', () => {
   const transaction = {
     pet_id: '1123123',
     value: 100,
-    date: '01-01-2020',
+    date: new Date('2020-01-01').toISOString(),
   };
 
   let transaction_id = '';
@@ -17,7 +17,7 @@ describe('CRUD transaction', () => {
       .set('Accept', 'application/json')
       .send(transaction);
     expect(res.status).toBe(201);
-    expect(res.body.value).toBe(transaction.value);
+    expect(res.body).toMatchObject(transaction);
 
     transaction_id = res.body._id;
   });
@@ -38,7 +38,7 @@ describe('CRUD transaction', () => {
   });
   it('delete transaction', async () => {
     const res = await request(app)
-      .put(`/transaction/${transaction_id}`)
+      .delete(`/transaction/${transaction_id}`)
       .set('Accept', 'application/json');
     expect(res.status).toBe(200);
   });

--- a/__tests__/user.spec.ts
+++ b/__tests__/user.spec.ts
@@ -1,7 +1,7 @@
 import request from 'supertest';
 import { app } from '../src/main';
 
-describe('GET /user', () => {});
+describe('GET /user', () => { });
 
 describe('CRUD user', () => {
   const user = {
@@ -20,7 +20,7 @@ describe('CRUD user', () => {
       .set('Accept', 'application/json')
       .send(user);
     expect(res.status).toBe(201);
-    expect(res.body.name).toBe(user.name);
+    expect(res.body).toMatchObject(user);
 
     user_id = res.body._id;
   });
@@ -40,7 +40,7 @@ describe('CRUD user', () => {
   });
   it('delete user', async () => {
     const res = await request(app)
-      .put(`/user/${user_id}`)
+      .delete(`/user/${user_id}`)
       .set('Accept', 'application/json');
     expect(res.status).toBe(200);
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -4289,9 +4289,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
     },
     "mixin-deep": {

--- a/src/controllers/base.controller.ts
+++ b/src/controllers/base.controller.ts
@@ -2,11 +2,16 @@ import { Request, Response } from 'express';
 import { BaseService } from 'services/base.service';
 import { IBaseModel } from '../models';
 
+export interface IControllerModelKeys<T> {
+  create: Array<keyof T>
+  update: Array<keyof T>
+}
+
 export abstract class BaseController<
   A extends IBaseModel,
   S extends BaseService<A>
-> {
-  constructor(protected service: S) {}
+  > {
+  constructor(protected service: S, protected keys: IControllerModelKeys<A>) { }
 
   getAll = async (req: Request, res: Response) => {
     try {
@@ -19,7 +24,7 @@ export abstract class BaseController<
 
   create = async (req: Request, res: Response) => {
     try {
-      const model = req.body;
+      const model = this.keys.create.reduce((obj, key) => ({ ...obj, ...{ [key]: req.body[key] } }), {} as A);
       const reg = await this.service.create(model);
       res.status(201).json(reg);
     } catch (error) {
@@ -29,7 +34,7 @@ export abstract class BaseController<
   update = async (req: Request, res: Response) => {
     try {
       const id = req.params.id;
-      const model = req.body;
+      const model = this.keys.update.reduce((obj, key) => ({ ...obj, ...{ [key]: req.body[key] } }), {} as A);
       const reg = await this.service.update(id, model);
       res.json(reg);
     } catch (error) {

--- a/src/controllers/institution.controller.ts
+++ b/src/controllers/institution.controller.ts
@@ -6,9 +6,14 @@ import { IInstituitionModel } from '../models';
 class InstituitionController extends BaseController<
   IInstituitionModel,
   InstitutionService
-> {
+  > {
   constructor() {
-    super(institutionService);
+    super(institutionService, {
+      // keys do req.body que serão usados no create
+      create: ['name', 'foto', 'email', 'telefone', 'sobre', 'credito', 'valido', 'termo', 'pets'],
+      // keys do req.body que serão usados no update
+      update: ['name', 'foto', 'email', 'telefone', 'sobre', 'credito', 'valido', 'termo', 'pets']
+    });
   }
 }
 

--- a/src/controllers/pet.controller.ts
+++ b/src/controllers/pet.controller.ts
@@ -5,7 +5,12 @@ import { IPetModel } from '../models';
 
 class PetController extends BaseController<IPetModel, PetService> {
   constructor() {
-    super(petService);
+    super(petService, {
+      // keys do req.body que serão usados no create
+      create: ['name', 'foto', 'porte', 'sobre', 'idade', 'foiAdotado'],
+      // keys do req.body que serão usados no update
+      update: ['name', 'foto', 'porte', 'sobre', 'idade', 'foiAdotado']
+    });
   }
 }
 

--- a/src/controllers/transaction.controller.ts
+++ b/src/controllers/transaction.controller.ts
@@ -6,9 +6,14 @@ import { ITransactionModel } from '../models';
 class TransactionController extends BaseController<
   ITransactionModel,
   TransactionService
-> {
+  > {
   constructor() {
-    super(transactionService);
+    super(transactionService, {
+      // keys do req.body que serão usados no create
+      create: ['pet_id', 'value', 'date'],
+      // keys do req.body que serão usados no update
+      update: ['pet_id', 'value', 'date']
+    });
   }
 }
 

--- a/src/controllers/user.controller.ts
+++ b/src/controllers/user.controller.ts
@@ -5,7 +5,12 @@ import { IUserModel } from '../models';
 
 class UserController extends BaseController<IUserModel, UserService> {
   constructor() {
-    super(userService);
+    super(userService, {
+      // keys do req.body que serão usados no create
+      create: ['name', 'foto', 'email', 'telefone', 'sobre', 'credito'],
+      // keys do req.body que serão usados no update
+      update: ['name', 'foto', 'email', 'telefone', 'sobre', 'credito']
+    });
   }
 }
 

--- a/src/models/pet.model.ts
+++ b/src/models/pet.model.ts
@@ -31,7 +31,7 @@ export const PetSchema = new Schema<IPetModel>({
     required: true,
   },
   foiAdotado: {
-    type: Number,
+    type: Boolean,
     required: true,
   },
 });

--- a/src/services/base.service.ts
+++ b/src/services/base.service.ts
@@ -1,7 +1,7 @@
 import { IBaseModel } from '../models';
 import { Model } from 'mongoose';
 export abstract class BaseService<A extends IBaseModel> {
-  constructor(protected BaseModel: Model<A>) {}
+  constructor(protected BaseModel: Model<A>) { }
   async getAll() {
     const res = await this.BaseModel.find();
     return res;
@@ -40,6 +40,7 @@ export abstract class BaseService<A extends IBaseModel> {
     try {
       const reg = await this.BaseModel.findById(id);
       if (reg) {
+        Object.assign(reg, model) // pega os dados de "model" e joga para "reg"
         const res = await reg.save();
         return res;
       }

--- a/test-report.xml
+++ b/test-report.xml
@@ -1,27 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testExecutions version="1">
-  <file path="/home/david/github/davidpvilaca/Adotei-back/__tests__/institution.spec.ts">
-    <testCase name="CRUD instituition create instituition" duration="601"/>
-    <testCase name="CRUD instituition get the instituition" duration="59"/>
-    <testCase name="CRUD instituition update instituition" duration="82"/>
-    <testCase name="CRUD instituition delete instituition" duration="87"/>
-  </file>
-  <file path="/home/david/github/davidpvilaca/Adotei-back/__tests__/transaction.spec.ts">
-    <testCase name="CRUD transaction create transaction" duration="438"/>
-    <testCase name="CRUD transaction get the transaction" duration="49"/>
-    <testCase name="CRUD transaction update transaction" duration="83"/>
-    <testCase name="CRUD transaction delete transaction" duration="78"/>
+  <file path="/home/david/github/davidpvilaca/Adotei-back/__tests__/pet.spec.ts">
+    <testCase name="CRUD pet create pet" duration="538"/>
+    <testCase name="CRUD pet get the pet" duration="52"/>
+    <testCase name="CRUD pet update pet" duration="96"/>
+    <testCase name="CRUD pet delete pet" duration="59"/>
   </file>
   <file path="/home/david/github/davidpvilaca/Adotei-back/__tests__/user.spec.ts">
-    <testCase name="CRUD user create user" duration="455"/>
-    <testCase name="CRUD user get the user" duration="47"/>
-    <testCase name="CRUD user update user" duration="83"/>
-    <testCase name="CRUD user delete user" duration="80"/>
+    <testCase name="CRUD user create user" duration="491"/>
+    <testCase name="CRUD user get the user" duration="49"/>
+    <testCase name="CRUD user update user" duration="86"/>
+    <testCase name="CRUD user delete user" duration="51"/>
   </file>
-  <file path="/home/david/github/davidpvilaca/Adotei-back/__tests__/pet.spec.ts">
-    <testCase name="CRUD pet create pet" duration="478"/>
-    <testCase name="CRUD pet get the pet" duration="53"/>
-    <testCase name="CRUD pet update pet" duration="77"/>
-    <testCase name="CRUD pet delete pet" duration="81"/>
+  <file path="/home/david/github/davidpvilaca/Adotei-back/__tests__/institution.spec.ts">
+    <testCase name="CRUD instituition create instituition" duration="477"/>
+    <testCase name="CRUD instituition get the instituition" duration="55"/>
+    <testCase name="CRUD instituition update instituition" duration="86"/>
+    <testCase name="CRUD instituition delete instituition" duration="54"/>
+  </file>
+  <file path="/home/david/github/davidpvilaca/Adotei-back/__tests__/transaction.spec.ts">
+    <testCase name="CRUD transaction create transaction" duration="449"/>
+    <testCase name="CRUD transaction get the transaction" duration="43"/>
+    <testCase name="CRUD transaction update transaction" duration="75"/>
+    <testCase name="CRUD transaction delete transaction" duration="46"/>
   </file>
 </testExecutions>

--- a/test-report.xml
+++ b/test-report.xml
@@ -1,27 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testExecutions version="1">
-  <file path="/workspace/Adotei-back/__tests__/transaction.spec.ts">
-    <testCase name="CRUD transaction create transaction" duration="3038"/>
-    <testCase name="CRUD transaction get the transaction" duration="194"/>
-    <testCase name="CRUD transaction update transaction" duration="364"/>
-    <testCase name="CRUD transaction delete transaction" duration="363"/>
+  <file path="/home/david/github/davidpvilaca/Adotei-back/__tests__/institution.spec.ts">
+    <testCase name="CRUD instituition create instituition" duration="601"/>
+    <testCase name="CRUD instituition get the instituition" duration="59"/>
+    <testCase name="CRUD instituition update instituition" duration="82"/>
+    <testCase name="CRUD instituition delete instituition" duration="87"/>
   </file>
-  <file path="/workspace/Adotei-back/__tests__/pet.spec.ts">
-    <testCase name="CRUD pet create pet" duration="3043"/>
-    <testCase name="CRUD pet get the pet" duration="196"/>
-    <testCase name="CRUD pet update pet" duration="358"/>
-    <testCase name="CRUD pet delete pet" duration="353"/>
+  <file path="/home/david/github/davidpvilaca/Adotei-back/__tests__/transaction.spec.ts">
+    <testCase name="CRUD transaction create transaction" duration="438"/>
+    <testCase name="CRUD transaction get the transaction" duration="49"/>
+    <testCase name="CRUD transaction update transaction" duration="83"/>
+    <testCase name="CRUD transaction delete transaction" duration="78"/>
   </file>
-  <file path="/workspace/Adotei-back/__tests__/user.spec.ts">
-    <testCase name="CRUD user create user" duration="2955"/>
-    <testCase name="CRUD user get the user" duration="198"/>
-    <testCase name="CRUD user update user" duration="360"/>
-    <testCase name="CRUD user delete user" duration="352"/>
+  <file path="/home/david/github/davidpvilaca/Adotei-back/__tests__/user.spec.ts">
+    <testCase name="CRUD user create user" duration="455"/>
+    <testCase name="CRUD user get the user" duration="47"/>
+    <testCase name="CRUD user update user" duration="83"/>
+    <testCase name="CRUD user delete user" duration="80"/>
   </file>
-  <file path="/workspace/Adotei-back/__tests__/institution.spec.ts">
-    <testCase name="CRUD instituition create instituition" duration="2970"/>
-    <testCase name="CRUD instituition get the instituition" duration="203"/>
-    <testCase name="CRUD instituition update instituition" duration="367"/>
-    <testCase name="CRUD instituition delete instituition" duration="353"/>
+  <file path="/home/david/github/davidpvilaca/Adotei-back/__tests__/pet.spec.ts">
+    <testCase name="CRUD pet create pet" duration="478"/>
+    <testCase name="CRUD pet get the pet" duration="53"/>
+    <testCase name="CRUD pet update pet" duration="77"/>
+    <testCase name="CRUD pet delete pet" duration="81"/>
   </file>
 </testExecutions>


### PR DESCRIPTION
- corrigi o funcionamento do update que não estava modificando o registro que se pedia
- adicionei um array de keys (chaves do objeto) para identificar quais chaves usar para criação e para atualização de registros
- corrigi funcionamento dos testes, na hora do delete estava fazendo PUT

Veja o exemplo de criação abaixo:
![image](https://user-images.githubusercontent.com/9597125/76956385-b66a1000-68f2-11ea-8b3a-33e9fed20a8e.png)
As chaves `foraDasKeys` e `outraChaveQueNaoPodeIr` foram enviados, porém o controlador pegou apenas as chaves do modelo que foram definidas no construtor do pet controller.

Na atualização esse comportamento se repete:
![image](https://user-images.githubusercontent.com/9597125/76956489-e87b7200-68f2-11ea-81bf-55842010a0a6.png)
